### PR TITLE
Edge 18 implements KeyboardEvent.repeat, but always return false.

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1799,7 +1799,8 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "12"
+              "version_added": null,
+              "notes": "Edge 18 implements this property, but always return false."
             },
             "firefox": {
               "version_added": "28"


### PR DESCRIPTION
Test code :
    document.addEventListener('keydown', e=>console.log(e.repeat))
    document.addEventListener('keyup', e=>console.log(e.repeat))
    document.addEventListener('keypress', e=>console.log(e.repeat))
